### PR TITLE
Png rendering

### DIFF
--- a/sanitiser/Cargo.toml
+++ b/sanitiser/Cargo.toml
@@ -9,7 +9,7 @@ uuid = { workspace = true }
 image = "0.25.6"
 # Using PDF libraries from: https://github.com/bblanchon/pdfium-binaries
 pdfium-render = { version = "0.8.34", features = ["image"] }
-printpdf = { version = "0.8.2", features = ["jpeg"] }
+printpdf = { version = "0.8.2", features = ["png"] }
 lopdf = "0.36.0"
 thiserror = "2.0.12"
 tracing = { version = "0.1.41" }

--- a/sanitiser/src/pdf/sanitise.rs
+++ b/sanitiser/src/pdf/sanitise.rs
@@ -426,11 +426,9 @@ mod tests {
             .expect("Failed to get regenerated file size")
             .len();
 
-        // The regenerated file should exist and have some content.
-        // The rengerated file is generally 10x larger than the original one
-        // So there is no point in comparing exact file sizes
+        // For some files, the regenerated file can be even smaller than the original one.
         assert!(
-            regenerated_size > original_size,
+            regenerated_size < original_size,
             "Regenerated file should be larger than original file"
         );
     }

--- a/sanitiser/src/pdf/sanitise.rs
+++ b/sanitiser/src/pdf/sanitise.rs
@@ -119,7 +119,7 @@ where
                     let new_container = PdfBitmap::empty(
                         target_render_width,
                         target_render_height,
-                        PdfBitmapFormat::BGR,
+                        PdfBitmapFormat::BGRA,
                         pdfium.bindings(),
                     )?;
                     bitmap_container = Some(new_container);
@@ -135,21 +135,21 @@ where
                 &PdfRenderConfig::new()
                     .set_target_width(target_render_width)
                     .set_target_height(target_render_height)
-                    .set_format(PdfBitmapFormat::BGR),
+                    .set_format(PdfBitmapFormat::BGRA),
             )?;
 
             // Rasterize the page at the new higher resolution
-            let bitmap = rendering_container.as_image().to_rgb8();
-            let mut jpg_data = Vec::new();
+            let bitmap = rendering_container.as_image().to_rgba8();
+            let mut png_data = Vec::new();
 
-            bitmap.write_to(&mut Cursor::new(&mut jpg_data), image::ImageFormat::Jpeg)?;
+            bitmap.write_to(&mut Cursor::new(&mut png_data), image::ImageFormat::Png)?;
             // Put back the reusable rendering container
             // So we can reference it again on the next loop run
             // preventing allocating another buffer
             bitmap_container = Some(rendering_container);
 
             let mut warnings = Vec::new();
-            let image = RawImage::decode_from_bytes(&jpg_data, &mut warnings)
+            let image = RawImage::decode_from_bytes(&png_data, &mut warnings)
                 .map_err(PDFRegenerationError::BadImageDecoding)?;
 
             let image_id = doc_out.add_image(&image);

--- a/sanitiser/src/pdf/sanitise.rs
+++ b/sanitiser/src/pdf/sanitise.rs
@@ -119,7 +119,7 @@ where
                     let new_container = PdfBitmap::empty(
                         target_render_width,
                         target_render_height,
-                        PdfBitmapFormat::BGRA,
+                        PdfBitmapFormat::BGR,
                         pdfium.bindings(),
                     )?;
                     bitmap_container = Some(new_container);
@@ -135,11 +135,11 @@ where
                 &PdfRenderConfig::new()
                     .set_target_width(target_render_width)
                     .set_target_height(target_render_height)
-                    .set_format(PdfBitmapFormat::BGRA),
+                    .set_format(PdfBitmapFormat::BGR),
             )?;
 
             // Rasterize the page at the new higher resolution
-            let bitmap = rendering_container.as_image().to_rgba8();
+            let bitmap = rendering_container.as_image().to_rgb8();
             let mut png_data = Vec::new();
 
             bitmap.write_to(&mut Cursor::new(&mut png_data), image::ImageFormat::Png)?;


### PR DESCRIPTION
## Description

Render PNGs without the alpha channel as objects in the final PDF as it renders much smaller final files compared with JPEGs.